### PR TITLE
Show native breadcrumbs in product page to avoid empty breadcrumbs block

### DIFF
--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -27,5 +27,10 @@
                 <argument name="zone" xsi:type="boolean">false</argument>
             </arguments>
         </referenceBlock>
+        <referenceBlock name="breadcrumbs">
+            <action method="setTemplate">
+                <argument name="template" xsi:type="string">Magento_Catalog::product/breadcrumbs.phtml</argument>
+            </action>
+        </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
Hi @davidwindell ,

This is a pull request to fix an annoying issue: breadcrumbs disappear from the product page after installing the extension.

In the module, the breadcrumbs template globally in the default.xml block. But the product page has a different breadcrumbs logic than the rest of the sections. Because of this, the breadcrumbs block disappear from the product page.

This is a temporary solution waiting for a fix which includes the breadcrumbs code for the product page.