### PR TITLE
Improve support for multiple product attribute types

### DIFF
--- a/Model/Type/Product.php
+++ b/Model/Type/Product.php
@@ -421,9 +421,9 @@ class Product
                 return $this->getAttributeText($field);
             }
         } elseif ($this->_product->getColor()) { // removing these lines will require a major version bump
-            $data['color'] = $this->escapeQuote((string)$this->getAttributeText('color'));
+            return $this->getAttributeText('color');
        	} elseif ($this->_product->getColour()) {
-            $data['color'] = $this->escapeQuote((string)$this->getAttributeText('colour'));
+            return $this->getAttributeText('colour');
         }
 
         return false;
@@ -475,6 +475,10 @@ class Product
     public function getAttributeText($attribute)
     {
         $attributeText = $this->_product->getAttributeText($attribute);
+        if ($attributeText === false) {
+            $attributeText = $this->_product->getData($attribute);
+        }
+
         if (is_array($attributeText)) {
             $attributeText = implode(', ', $attributeText);
         }


### PR DESCRIPTION
Fixes #102

1. Updated getAttributeText(): Modified this method to fallback to $this->_product->getData($attribute) if $this->_product->getAttributeText($attribute) returns false. This ensures that plain text attributes are correctly retrieved while still supporting select/multiselect attributes.

2. Refactored getColor(): Fixed incorrect assigning to `$data` variable. Return the attribute value directly from getAttributeText() and remove double escaping.