### PR TITLE
Fix/cms page json ld validation

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,6 +12,7 @@
             </product>
             <contact>
                 <type>Organization</type>
+                <enable_home>1</enable_home>
             </contact>
         </structureddata>
     </default>

--- a/view/frontend/templates/jsonld.phtml
+++ b/view/frontend/templates/jsonld.phtml
@@ -4,8 +4,11 @@
 <script type="application/ld+json" id="structured-data">
 {
     "@context": "https://schema.org/",
-    "@type": "<?= $block->escapeQuote($block->getPageType()) ?>",
-    "publisher": {
+    "@type": "<?= $block->escapeQuote($block->getPageType()) ?>"
+    <?php if ($block->getPageType() === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE): ?>
+    ,"url": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>"
+    <?php endif; ?>
+    ,"publisher": {
         "@type": "Organization",
         "name": "<?= $block->escapeQuote($block->getConfig('general/store_information/name') ?? ''); ?>",
         "url": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>",

--- a/view/frontend/templates/jsonld.phtml
+++ b/view/frontend/templates/jsonld.phtml
@@ -1,31 +1,31 @@
 <!-- Structured Data by outer/edge (https://outeredge.agency) -->
-<?php $mainEntity = $block->getChildHtml('main.entity'); ?>
-<?php $additionalSchema = $block->getChildHtml('additional.schema'); ?>
+<?php
+/** @var \OuterEdge\StructuredData\Block\Jsonld $block */
+$mainEntity = $block->getChildHtml('main.entity');
+$additionalSchema = $block->getChildHtml('additional.schema');
+$isWebsite = $block->getPageType() === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE;
+$storeName = (string) ($block->getConfig('general/store_information/name') ?? '');
+$baseUrl = $block->getStore()->getBaseUrl();
+$logoUrl = (string) ($block->getStoreLogoUrl() ?? '');
+?>
 <script type="application/ld+json" id="structured-data">
 {
     "@context": "https://schema.org/",
     "@type": "<?= $block->escapeQuote($block->getPageType()) ?>"
-    <?php if ($block->getPageType() === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE): ?>
-    ,"url": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>"
-    ,"potentialAction": {
-        "@type": "SearchAction",
-        "target": {
-            "@type": "EntryPoint",
-            "urlTemplate": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>catalogsearch/result/?q={search_term_string}"
-        },
-        "query-input": "required name=search_term_string"
-    }
+    <?php if ($isWebsite): ?>
+    ,"url": <?= /* @noEscape */ json_encode($baseUrl, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>
+    ,"name": <?= /* @noEscape */ json_encode($storeName, JSON_UNESCAPED_UNICODE); ?>
     <?php endif; ?>
     ,"publisher": {
         "@type": "Organization",
-        "name": "<?= $block->escapeQuote($block->getConfig('general/store_information/name') ?? ''); ?>",
-        "url": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>",
+        "name": <?= /* @noEscape */ json_encode($storeName, JSON_UNESCAPED_UNICODE); ?>,
+        "url": <?= /* @noEscape */ json_encode($baseUrl, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>,
         "logo": {
             "@type": "ImageObject",
-            "url": "<?= $block->escapeUrl($block->escapeQuote($block->getStoreLogoUrl()) ?? ''); ?>"
+            "url": <?= /* @noEscape */ json_encode($logoUrl, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>
         }
     }
-    <?php if ($mainEntity): ?>
+    <?php if ($mainEntity && !$isWebsite): ?>
     ,
     "mainEntity": <?= /* @noEscape */ $mainEntity; ?>
     <?php endif; ?>
@@ -34,4 +34,9 @@
     <?php endif; ?>
 }
 </script>
+<?php if ($isWebsite && $mainEntity): ?>
+<script type="application/ld+json" id="structured-data-organization">
+<?= /* @noEscape */ $mainEntity; ?>
+</script>
+<?php endif; ?>
 <?= $block->getChildHtml('product.offers.schema'); ?>

--- a/view/frontend/templates/jsonld.phtml
+++ b/view/frontend/templates/jsonld.phtml
@@ -7,6 +7,14 @@
     "@type": "<?= $block->escapeQuote($block->getPageType()) ?>"
     <?php if ($block->getPageType() === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE): ?>
     ,"url": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>"
+    ,"potentialAction": {
+        "@type": "SearchAction",
+        "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>catalogsearch/result/?q={search_term_string}"
+        },
+        "query-input": "required name=search_term_string"
+    }
     <?php endif; ?>
     ,"publisher": {
         "@type": "Organization",

--- a/view/frontend/templates/jsonld/cms.phtml
+++ b/view/frontend/templates/jsonld/cms.phtml
@@ -1,16 +1,23 @@
-,"name": <?= /* @escapeNotVerified */ json_encode((string) $block->stripTags($block->getTitle()), JSON_UNESCAPED_UNICODE); ?>
+<?php
+/** @var \OuterEdge\StructuredData\Block\Cms $block */
+// Homepage is typed as WebSite; CMS-page properties belong on WebPage only.
+if ($block->getPageType() === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE) {
+    return;
+}
+?>
+,"name": <?= /* @noEscape */ json_encode((string) $block->stripTags($block->getTitle()), JSON_UNESCAPED_UNICODE); ?>
 <?php $content = trim((string) $block->stripTags($block->getContent())); ?>
-<?php if ($content && $block->getPageType() !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE): ?>
+<?php if ($content): ?>
 ,"mainContentOfPage": {
-    "text": <?= /* @escapeNotVerified */ json_encode($content, JSON_UNESCAPED_UNICODE); ?>
+    "text": <?= /* @noEscape */ json_encode($content, JSON_UNESCAPED_UNICODE); ?>
 }
 <?php endif; ?>
 <?php if ($block->getMetaDescription()): ?>
-    ,"description": <?= /* @escapeNotVerified */ json_encode(preg_replace('/\s+/', ' ', trim($block->stripTags($block->getMetaDescription()))), JSON_UNESCAPED_UNICODE); ?>
+    ,"description": <?= /* @noEscape */ json_encode(preg_replace('/\s+/', ' ', trim($block->stripTags($block->getMetaDescription()))), JSON_UNESCAPED_UNICODE); ?>
 <?php endif; ?>
-<?php if ($block->getImage() && $block->getPageType() !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE): ?>
+<?php if ($block->getImage()): ?>
     ,"primaryImageOfPage": {
         "@type": "ImageObject",
-        "url": <?= /* @escapeNotVerified */ json_encode((string) $block->getImage(), JSON_UNESCAPED_UNICODE); ?>
+        "url": <?= /* @noEscape */ json_encode((string) $block->getImage(), JSON_UNESCAPED_UNICODE); ?>
     }
 <?php endif; ?>

--- a/view/frontend/templates/jsonld/cms.phtml
+++ b/view/frontend/templates/jsonld/cms.phtml
@@ -1,16 +1,16 @@
-,"name": "<?= $block->escapeQuote($block->stripTags($block->getTitle())); ?>"
-<?php $content = $block->getContent(); ?>
-<?php if ($content): ?>
+,"name": <?= /* @escapeNotVerified */ json_encode((string) $block->stripTags($block->getTitle()), JSON_UNESCAPED_UNICODE); ?>
+<?php $content = trim((string) $block->stripTags($block->getContent())); ?>
+<?php if ($content && $block->getPageType() !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE): ?>
 ,"mainContentOfPage": {
-    "text": "<?= $block->escapeQuote($block->stripTags($content)); ?>"
+    "text": <?= /* @escapeNotVerified */ json_encode($content, JSON_UNESCAPED_UNICODE); ?>
 }
 <?php endif; ?>
 <?php if ($block->getMetaDescription()): ?>
-    ,"description": "<?= $block->escapeQuote(preg_replace('/\s+/', ' ', trim($block->stripTags($block->getMetaDescription())))); ?>"
+    ,"description": <?= /* @escapeNotVerified */ json_encode(preg_replace('/\s+/', ' ', trim($block->stripTags($block->getMetaDescription()))), JSON_UNESCAPED_UNICODE); ?>
 <?php endif; ?>
-<?php if ($block->getImage()): ?>
+<?php if ($block->getImage() && $block->getPageType() !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE): ?>
     ,"primaryImageOfPage": {
         "@type": "ImageObject",
-        "url": "<?= $block->escapeQuote($block->getImage()); ?>"
+        "url": <?= /* @escapeNotVerified */ json_encode((string) $block->getImage(), JSON_UNESCAPED_UNICODE); ?>
     }
 <?php endif; ?>

--- a/view/frontend/templates/jsonld/organization.phtml
+++ b/view/frontend/templates/jsonld/organization.phtml
@@ -1,41 +1,69 @@
-{
-    "@type": "<?= $block->escapeQuote($block->getConfig('structureddata/contact/type')); ?>",
-    "@id": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>",
-    "name": "<?= $block->escapeQuote($block->getConfig('general/store_information/name') ?? ''); ?>",
-    "image": "<?= $block->escapeUrl($block->getStoreLogoUrl() ?? ''); ?>",
-    <?php if (trim($block->escapeQuote($block->getStreetAddress()), ' ,\t\n\r\0\x0B') !== ''): ?>
-    "address": {
-        "@type": "PostalAddress",
-        "streetAddress": "<?= $block->escapeQuote($block->getStreetAddress()); ?>",
-        <?php if ($block->getConfig('general/store_information/city')):?>
-        "addressLocality": "<?= $block->escapeQuote($block->getConfig('general/store_information/city')); ?>",
-        <?php endif; ?>
-        <?php if ($block->getConfig('general/store_information/region_id')):?>
-        "addressRegion": "<?= $block->escapeQuote($block->getConfig('general/store_information/region_id')); ?>",
-        <?php endif; ?>
-        <?php if ($block->getConfig('general/store_information/postcode')):?>
-        "postalCode": "<?= $block->escapeQuote((string)$block->getConfig('general/store_information/postcode')); ?>",
-        <?php endif; ?>
-        <?php if ($block->getConfig('general/store_information/country_id')):?>
-        "addressCountry": "<?= $block->escapeQuote($block->getConfig('general/store_information/country_id')); ?>"
-        <?php endif; ?>
-    },
-    <?php endif; ?>
-    <?php if ($block->getConfig('general/store_information/phone')):?>
-    "telephone": "<?= $block->escapeQuote((string)$block->getConfig('general/store_information/phone')); ?>",
-    <?php endif; ?>
-    <?php if ($block->getConfig('trans_email/ident_general/email')):?>
-    "email": "<?= $block->escapeQuote($block->getConfig('trans_email/ident_general/email')); ?>",
-    <?php endif; ?>
-    "url": "<?= $block->escapeUrl($block->getStore()->getBaseUrl()); ?>"
-    <?php if ($block->isLocalBusiness() && trim($block->getConfig('structureddata/contact/latitude')) !== ''): ?>
-    ,"geo": {
-        "@type": "GeoCoordinates",
-        "latitude": "<?= $block->escapeQuote((string)$block->getConfig('structureddata/contact/latitude')) ?>",
-        "longitude": "<?= $block->escapeQuote((string)$block->getConfig('structureddata/contact/longitude')) ?>"
-    }
-    <?php endif; ?>
-    <?php if ($block->getRelatedPages()): ?>
-    ,"sameAs": <?= $block->escapeQuote($block->getRelatedPages()) ?>
-    <?php endif; ?>
+<?php
+/** @var \OuterEdge\StructuredData\Block\Organization $block */
+$orgType = (string) $block->getConfig('structureddata/contact/type');
+$baseUrl = $block->getStore()->getBaseUrl();
+$storeName = (string) ($block->getConfig('general/store_information/name') ?? '');
+$logoUrl = (string) ($block->getStoreLogoUrl() ?? '');
+$street = trim($block->getStreetAddress(), " ,\t\n\r\0\x0B");
+$city = (string) ($block->getConfig('general/store_information/city') ?? '');
+$region = (string) ($block->getConfig('general/store_information/region_id') ?? '');
+$postcode = (string) ($block->getConfig('general/store_information/postcode') ?? '');
+$country = (string) ($block->getConfig('general/store_information/country_id') ?? '');
+$phone = (string) ($block->getConfig('general/store_information/phone') ?? '');
+$email = (string) ($block->getConfig('trans_email/ident_general/email') ?? '');
+
+$organization = [
+    '@context' => 'https://schema.org/',
+    '@type' => $orgType ?: 'Organization',
+    '@id' => $baseUrl,
+    'name' => $storeName,
+    'url' => $baseUrl,
+];
+
+if ($logoUrl !== '') {
+    $organization['logo'] = $logoUrl;
+    $organization['image'] = $logoUrl;
 }
+
+if ($street !== '') {
+    $address = ['@type' => 'PostalAddress', 'streetAddress' => $street];
+    if ($city !== '') {
+        $address['addressLocality'] = $city;
+    }
+    if ($region !== '') {
+        $address['addressRegion'] = $region;
+    }
+    if ($postcode !== '') {
+        $address['postalCode'] = $postcode;
+    }
+    if ($country !== '') {
+        $address['addressCountry'] = $country;
+    }
+    $organization['address'] = $address;
+}
+
+if ($phone !== '') {
+    $organization['telephone'] = $phone;
+}
+
+if ($email !== '') {
+    $organization['email'] = $email;
+}
+
+if ($block->isLocalBusiness() && trim((string) $block->getConfig('structureddata/contact/latitude')) !== '') {
+    $organization['geo'] = [
+        '@type' => 'GeoCoordinates',
+        'latitude' => (string) $block->getConfig('structureddata/contact/latitude'),
+        'longitude' => (string) $block->getConfig('structureddata/contact/longitude'),
+    ];
+}
+
+$relatedPages = $block->getRelatedPages();
+if ($relatedPages) {
+    $decoded = json_decode($relatedPages, true);
+    if (is_array($decoded) && $decoded !== []) {
+        $organization['sameAs'] = $decoded;
+    }
+}
+
+echo /* @noEscape */ json_encode($organization, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);


### PR DESCRIPTION
## Summary
- Fix invalid JSON-LD on CMS pages (use json_encode; drop invalid WebSite properties)
- Add root WebSite url/name for Site Names
- Emit top-level Organization schema on homepage (SearchAction removed — deprecated by Google Oct 2024)
- Default enable_home=1 for Organization on homepage