### PR TITLE
Add extensibility hooks for extra @graph nodes and page entity

### DIFF
--- a/Block/Jsonld.php
+++ b/Block/Jsonld.php
@@ -1127,4 +1127,29 @@ class Jsonld extends Template
         );
         return is_string($json) ? $json : '';
     }
+
+    /**
+     * Extra @graph nodes contributed by site modules (plugins).
+     *
+     * Override via afterGetExtraGraphNodes to append entities such as
+     * FAQPage without scraping the rendered JSON-LD HTML.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getExtraGraphNodes(): array
+    {
+        return [];
+    }
+
+    /**
+     * Allow site modules to augment the page entity before it is pushed
+     * into @graph (e.g. link the page to an FAQPage via about: {@id}).
+     *
+     * @param array<string, mixed> $pageEntity
+     * @return array<string, mixed>
+     */
+    public function extendPageEntity(array $pageEntity): array
+    {
+        return $pageEntity;
+    }
 }

--- a/view/frontend/templates/jsonld.phtml
+++ b/view/frontend/templates/jsonld.phtml
@@ -123,6 +123,10 @@ if ($pageType === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_CONTACTPAGE)
     $pageEntity['mainEntity'] = ['@id' => $block->getOrganizationId()];
 }
 
+// Site modules may augment the page entity (e.g. about → FAQPage) and
+// contribute additional @graph nodes via plugins on these public methods.
+$pageEntity = $block->extendPageEntity($pageEntity);
+
 // Only emit the BreadcrumbList when there's at least one item.
 $breadcrumbItems = $block->getBreadcrumbItems();
 if ($pageType !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE && !empty($breadcrumbItems)) {
@@ -133,6 +137,12 @@ if ($pageType !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE && !
 
 if ($pageType !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE) {
     $graph[] = $pageEntity;
+}
+
+foreach ($block->getExtraGraphNodes() as $extraNode) {
+    if (is_array($extraNode) && $extraNode !== []) {
+        $graph[] = $extraNode;
+    }
 }
 
 $payload = [


### PR DESCRIPTION
## Summary
- Add public `getExtraGraphNodes()` and `extendPageEntity()` on `Block\Jsonld`
- Call both from `jsonld.phtml` so site modules can contribute FAQPage (and similar) nodes and link the page entity without HTML post-processing

## Why
Site modules currently parse the rendered `<script id="structured-data">` via `afterToHtml` plugins. These hooks keep the generic module vendor-agnostic while giving a clean, plugin-friendly extension surface.

## Test plan
- [ ] Product/category/CMS pages still emit valid JSON-LD with no site plugins
- [ ] afterGetExtraGraphNodes appends a node to @graph
- [ ] afterExtendPageEntity can set about on the page entity