### PR TITLE
Updates for GEO

### DIFF
--- a/Block/Category.php
+++ b/Block/Category.php
@@ -3,60 +3,90 @@
 namespace OuterEdge\StructuredData\Block;
 
 use Magento\Framework\View\Element\Template\Context;
-use Magento\Catalog\Block\Product\ListProduct;
 use Magento\Eav\Model\Entity\Collection\AbstractCollection;
 
 class Category extends \Magento\Framework\View\Element\Template
 {
-    /**
-     * @var ListProduct
-     */
-    protected $listProductBlock;
-
     /**
      * @var AbstractCollection
      */
     protected $_productCollection = null;
 
     public function __construct(
-        ListProduct $listProductBlock,
         Context $context,
         array $data = [])
     {
-        $this->listProductBlock = $listProductBlock;
-
         parent::__construct($context, $data);
+    }
+
+    /**
+     * Resolve the category product list block rendered on the page so
+     * structured data reflects the actual visible list (sorting, layered
+     * navigation, pagination, extensions, permissions).
+     */
+    private function getRenderedListBlock(): ?\Magento\Catalog\Block\Product\ListProduct
+    {
+        try {
+            $layout = $this->getLayout();
+            if (!$layout) {
+                return null;
+            }
+            $block = $layout->getBlock('category.products.list');
+            if ($block instanceof \Magento\Catalog\Block\Product\ListProduct) {
+                return $block;
+            }
+        } catch (\Throwable $e) {
+            return null;
+        }
+        return null;
     }
 
     public function getSchemaJson()
     {
-        $collection = $this->listProductBlock->getLoadedProductCollection();
-        return json_encode($this->getSchemaData($collection), JSON_UNESCAPED_SLASHES);
+        $collection = $this->getResolvedProductCollection();
+        if (!$collection) {
+            return '';
+        }
+        $schema = $this->getSchemaData($collection);
+        $encoded = json_encode(
+            $schema,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+        return is_string($encoded) ? $encoded : '';
+    }
+
+    private function getResolvedProductCollection(): ?AbstractCollection
+    {
+        $block = $this->getRenderedListBlock();
+        if ($block) {
+            $collection = $block->getLoadedProductCollection();
+            if ($collection instanceof AbstractCollection) {
+                return $collection;
+            }
+        }
+
+        return null;
     }
 
     public function getSchemaData(AbstractCollection $productCollection)
     {
-        if (!$this->_productCollection) {
-            $this->_productCollection = $productCollection;
-        }
+        $this->_productCollection = $productCollection;
 
         $listData = [];
 
         $i = 1;
         foreach ($this->_productCollection as $product) {
             $listData[] = [
-                "@context" => "https://schema.org/",
                 "@type" => "ListItem",
                 "position" => $i++,
-                "url" => $product->getProductUrl()
+                "url" => preg_replace('/[?#].*$/', '', (string) $product->getProductUrl()),
+                "name" => (string) $product->getName()
             ];
         }
 
-        $data = [
+        return [
             "@type" => "ItemList",
             "itemListElement" => $listData
         ];
-
-        return $data;
     }
 }

--- a/Block/Cms.php
+++ b/Block/Cms.php
@@ -12,6 +12,11 @@ use Magento\Theme\Block\Html\Header\Logo;
 use Magento\Theme\ViewModel\Block\Html\Header\LogoPathResolver;
 use OuterEdge\StructuredData\Block\Jsonld;
 use DOMDocument;
+use Magento\Framework\Registry;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Helper\Image as ImageHelper;
+use Magento\Framework\View\Page\Config as PageConfig;
 
 class Cms extends Jsonld
 {
@@ -47,6 +52,11 @@ class Cms extends Jsonld
         Logo $logo,
         LogoPathResolver $logoPathResolver,
         FilterProvider $filterProvider,
+        Registry $registry,
+        SerializerInterface $serializer,
+        CategoryRepositoryInterface $categoryRepository,
+        ImageHelper $imageHelper,
+        PageConfig $pageConfig,
         array $data = []
     ) {
         $this->_filterProvider = $filterProvider;
@@ -58,6 +68,11 @@ class Cms extends Jsonld
             $page,
             $logo,
             $logoPathResolver,
+            $registry,
+            $serializer,
+            $categoryRepository,
+            $imageHelper,
+            $pageConfig,
             $data
         );
     }

--- a/Block/Jsonld.php
+++ b/Block/Jsonld.php
@@ -10,6 +10,11 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Cms\Model\Page;
 use Magento\Framework\App\Request\Http;
+use Magento\Framework\Registry;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Helper\Image as ImageHelper;
+use Magento\Framework\View\Page\Config as PageConfig;
 
 class Jsonld extends Template
 {
@@ -54,7 +59,6 @@ class Jsonld extends Template
      * @param Page $page
      * @param Logo $logo
      * @param LogoPathResolver $logoPathResolver
-     * @param string $pageType
      * @param array $data
      * @codingStandardsIgnoreStart
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -66,6 +70,14 @@ class Jsonld extends Template
         Page $page,
         Logo $logo,
         LogoPathResolver $logoPathResolver,
+        protected Registry $registry,
+        protected SerializerInterface $serializer,
+        protected CategoryRepositoryInterface $categoryRepository,
+        protected ImageHelper $imageHelper,
+        // Untyped because Magento\Framework\View\Element\Template already
+        // declares a property named $pageConfig (without a type). PHP 8.x
+        // forbids adding a type to an inherited untyped property.
+        protected $pageConfig,
         array $data = []
     ) {
         $logo->setData('logoPathResolver', $logoPathResolver);
@@ -145,7 +157,7 @@ class Jsonld extends Template
         if (empty($aboutPage)) {
             return false;
         }
-        
+
         $currentPage = $this->getPage()->getIdentifier();
 
         if ($this->getConfig('structureddata/cms/enable_about') && $currentPage == $aboutPage) {
@@ -153,5 +165,991 @@ class Jsonld extends Template
         }
 
         return false;
+    }
+
+    public function getBaseUrl(): string
+    {
+        return rtrim($this->_storeManager->getStore()->getBaseUrl(), '/');
+    }
+
+    /**
+     * Structured-data base URL helper (per GEO fixes plan, Step 2).
+     * Same as getBaseUrl() but exposes an explicit, plan-named accessor for
+     * any callers that prefer the structured-data-specific name.
+     */
+    public function getStructuredDataBaseUrl(): string
+    {
+        return $this->getBaseUrl();
+    }
+
+    public function getOrganizationId(): string
+    {
+        return $this->getBaseUrl() . '/#org';
+    }
+
+    public function isCollectionPage(): bool
+    {
+        return $this->getPageType() === self::PAGE_TYPE_COLLECTIONPAGE;
+    }
+
+    public function getWebsiteId(): string
+    {
+        return $this->getBaseUrl() . '/#website';
+    }
+
+    public function getCurrentUrl(): string
+    {
+        $canonical = $this->getCanonicalPageUrl();
+        if ($canonical !== '') {
+            return $this->normalizeUrl($canonical);
+        }
+        return $this->normalizeUrl((string) $this->_storeManager->getStore()->getCurrentUrl(false));
+    }
+
+    /**
+     * Returns Magento's configured canonical page URL when available.
+     * Falls back to an empty string so callers can keep their default
+     * request-URL behavior.
+     */
+    public function getCanonicalPageUrl(): string
+    {
+        $assetUrl = $this->getCanonicalAssetUrl();
+        if ($assetUrl !== '') {
+            return $assetUrl;
+        }
+
+        try {
+            $product = $this->registry->registry('current_product');
+            if ($product && is_object($product)) {
+                $urlModel = $product->getUrlModel();
+                if ($urlModel && method_exists($urlModel, 'getUrl')) {
+                    $url = (string) $urlModel->getUrl($product, [
+                        '_ignore_category' => true,
+                        '_scope_to_url' => true,
+                    ]);
+                    if ($url !== '') {
+                        return $url;
+                    }
+                }
+            }
+
+            $category = $this->registry->registry('current_category');
+            if ($category && is_object($category) && method_exists($category, 'getUrl')) {
+                $url = (string) $category->getUrl();
+                if ($url !== '') {
+                    return $url;
+                }
+            }
+
+            $cmsPage = $this->registry->registry('cms_page');
+            if ($cmsPage && is_object($cmsPage) && method_exists($cmsPage, 'getIdentifier')) {
+                $identifier = trim((string) $cmsPage->getIdentifier(), '/');
+                if ($identifier !== '' && $identifier !== 'home') {
+                    return $this->getBaseUrl() . '/' . $identifier;
+                }
+                return $this->getBaseUrl() . '/';
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+        return '';
+    }
+
+    private function getCanonicalAssetUrl(): string
+    {
+        try {
+            $collection = $this->pageConfig->getAssetCollection();
+            if (!$collection || !method_exists($collection, 'getAll')) {
+                return '';
+            }
+            foreach ((array) $collection->getAll() as $key => $asset) {
+                if (!is_object($asset) || !method_exists($asset, 'getUrl')) {
+                    continue;
+                }
+                $isCanonical = method_exists($asset, 'getContentType')
+                    && strcasecmp((string) $asset->getContentType(), 'canonical') === 0;
+                $isCanonical = $isCanonical || stripos((string) $key, 'canonical') !== false;
+                if (method_exists($asset, 'getProperties')) {
+                    $properties = (array) $asset->getProperties();
+                    $attributes = (array) ($properties['attributes'] ?? []);
+                    $isCanonical = $isCanonical
+                        || strcasecmp((string) ($attributes['rel'] ?? ''), 'canonical') === 0;
+                }
+                if ($isCanonical) {
+                    $url = (string) $asset->getUrl();
+                    if ($url !== '') {
+                        return $url;
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            // Entity-specific canonical URLs are used as the fallback.
+        }
+        return '';
+    }
+
+    public function getBreadcrumbId(): string
+    {
+        return $this->getCurrentUrl() . '#breadcrumb';
+    }
+
+    public function getPageId(): string
+    {
+        return $this->getCurrentUrl() . '#webpage';
+    }
+
+    public function getPageTitle(): string
+    {
+        try {
+            $title = trim((string) $this->pageConfig->getTitle()->get());
+            if ($title !== '') {
+                return $title;
+            }
+        } catch (\Throwable $e) {
+            // Fall through to other sources.
+        }
+
+        try {
+            $product = $this->registry->registry('current_product');
+            if ($product && is_object($product) && method_exists($product, 'getName')) {
+                $name = trim((string) $product->getName());
+                if ($name !== '') {
+                    return $name;
+                }
+            }
+        } catch (\Throwable $e) {
+            // Ignore.
+        }
+
+        try {
+            $config = $this->_scopeConfig;
+            $title = (string) $config->getValue('design/head/default_title');
+            if ($title !== '') {
+                return $title;
+            }
+        } catch (\Throwable $e) {
+            // Ignore.
+        }
+
+        return '';
+    }
+
+    public function getStoreLocale(): string
+    {
+        try {
+            $locale = (string) $this->_scopeConfig->getValue(
+                'general/locale/code',
+                ScopeInterface::SCOPE_STORE
+            );
+            if ($locale !== '') {
+                return str_replace('_', '-', $locale);
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+        return 'en-GB';
+    }
+
+    /**
+     * Page description for the WebPage entity. Pulls from CMS meta, category
+     * description, or product description depending on page type. Long values
+     * are truncated to 300 chars to keep the WebPage.description field a true
+     * page summary (the Product node carries the full description).
+     */
+    public function getPageDescription(): string
+    {
+        $candidates = [];
+
+        // CMS pages use the dedicated block's meta description.
+        if ($this instanceof \OuterEdge\StructuredData\Block\Cms
+            && method_exists($this, 'getMetaDescription')
+        ) {
+            $candidates[] = (string) $this->getMetaDescription();
+        }
+
+        try {
+            $cmsPage = $this->registry->registry('cms_page');
+            if ($cmsPage && is_object($cmsPage) && method_exists($cmsPage, 'getMetaDescription')) {
+                $candidates[] = (string) $cmsPage->getMetaDescription();
+            }
+
+            $head = $this->getLayout() ? $this->getLayout()->getBlock('head') : false;
+            if ($head && method_exists($head, 'getMetaDescription')) {
+                $candidates[] = (string) $head->getMetaDescription();
+            }
+
+            $category = $this->registry->registry('current_category');
+            if ($category && is_object($category)) {
+                $candidates[] = (string) $category->getDescription();
+            }
+
+            $product = $this->registry->registry('current_product');
+            if ($product && is_object($product)) {
+                if (method_exists($product, 'getMetaDescription')) {
+                    $candidates[] = (string) $product->getMetaDescription();
+                }
+                $candidates[] = (string) $product->getShortDescription();
+                // Long description is only used if no shorter candidate exists.
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        foreach ($candidates as $raw) {
+            $clean = trim((string) preg_replace('/\s+/', ' ', strip_tags((string) $raw)));
+            if ($clean === '') {
+                continue;
+            }
+            if (mb_strlen($clean) > 300) {
+                $clean = rtrim(mb_substr($clean, 0, 300)) . '…';
+            }
+            return $clean;
+        }
+
+        // Final fallback: long product description, truncated.
+        try {
+            $product = $this->registry->registry('current_product');
+            if ($product && is_object($product)) {
+                $clean = trim((string) preg_replace('/\s+/', ' ', strip_tags((string) $product->getDescription())));
+                if ($clean !== '') {
+                    if (mb_strlen($clean) > 300) {
+                        $clean = rtrim(mb_substr($clean, 0, 300)) . '…';
+                    }
+                    return $clean;
+                }
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        return '';
+    }
+
+    /**
+     * Page last-modified timestamp (ISO-8601) for dateModified.
+     */
+    public function getPageDateModified(): string
+    {
+        $raw = '';
+
+        if ($this instanceof \OuterEdge\StructuredData\Block\Cms) {
+            try {
+                $page = $this->getPage();
+                if ($page) {
+                    $raw = (string) ($page->getUpdateTime() ?: $page->getCreationTime());
+                }
+            } catch (\Throwable $e) {
+                // ignore
+            }
+        }
+
+        if ($raw === '') {
+            try {
+                // Fall back to the cms_page registry entry.
+                $cmsPage = $this->registry->registry('cms_page');
+                if ($cmsPage && is_object($cmsPage)) {
+                    $raw = (string) (method_exists($cmsPage, 'getUpdateTime')
+                        ? ($cmsPage->getUpdateTime() ?: '')
+                        : '');
+                    if ($raw === '' && method_exists($cmsPage, 'getCreationTime')) {
+                        $raw = (string) ($cmsPage->getCreationTime() ?: '');
+                    }
+                }
+
+                if ($raw === '') {
+                    $category = $this->registry->registry('current_category');
+                    if ($category && is_object($category)) {
+                        $raw = (string) ($category->getUpdatedAt() ?: '');
+                    }
+                }
+                if ($raw === '') {
+                    $product = $this->registry->registry('current_product');
+                    if ($product && is_object($product)) {
+                        $raw = (string) ($product->getUpdatedAt() ?: '');
+                    }
+                }
+            } catch (\Throwable $e) {
+                // ignore
+            }
+        }
+
+        $raw = trim($raw);
+        if ($raw === '') {
+            return '';
+        }
+
+        try {
+            $dt = new \DateTimeImmutable($raw);
+            return $dt->format(\DateTimeInterface::ATOM);
+        } catch (\Throwable $e) {
+            return '';
+        }
+    }
+
+    /**
+     * primaryImageOfPage ImageObject (or empty array if not configured).
+     */
+    public function getPagePrimaryImage(): array
+    {
+        if ($this instanceof \OuterEdge\StructuredData\Block\Cms
+            && method_exists($this, 'getImage')
+        ) {
+            $url = (string) $this->getImage();
+            if ($url !== '') {
+                return [
+                    '@type' => 'ImageObject',
+                    'url' => $url,
+                ];
+            }
+        }
+
+        try {
+            $category = $this->registry->registry('current_category');
+            if ($category && is_object($category) && method_exists($category, 'getImageUrl')) {
+                $url = (string) $category->getImageUrl();
+                if ($url !== '') {
+                    return [
+                        '@type' => 'ImageObject',
+                        'url' => $url,
+                    ];
+                }
+            }
+
+            // On product pages (no current_category), use the product's
+            // main image so ItemPage.primaryImageOfPage is populated.
+            $product = $this->registry->registry('current_product');
+            if ($product && is_object($product)) {
+                $image = (string) $product->getImage();
+                if ($image !== '' && $image !== 'no_selection') {
+                    $url = (string) $this->imageHelper
+                        ->init($product, 'product_page_image_medium')
+                        ->getUrl();
+                    if ($url !== '' && !$this->isPlaceholderUrl($url)) {
+                        return [
+                            '@type' => 'ImageObject',
+                            'url' => $url,
+                        ];
+                    }
+                }
+                $galleryUrl = $this->resolveFirstGalleryImageUrl($product);
+                if ($galleryUrl !== '') {
+                    return [
+                        '@type' => 'ImageObject',
+                        'url' => $galleryUrl,
+                    ];
+                }
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOrganizationSchema(): array
+    {
+        $schema = [
+            '@type' => 'Organization',
+            '@id' => $this->getOrganizationId(),
+            'name' => (string) ($this->getConfig('general/store_information/name') ?? ''),
+            'url' => $this->getBaseUrl() . '/',
+            'inLanguage' => $this->getStoreLocale(),
+        ];
+
+        $logo = $this->getStoreLogoUrl();
+        if ($logo) {
+            $schema['logo'] = [
+                '@type' => 'ImageObject',
+                'url' => $logo,
+            ];
+        }
+
+        $sameAs = $this->getSameAsUrls();
+        if ($sameAs) {
+            $schema['sameAs'] = $sameAs;
+        }
+
+        $description = $this->getOrganizationDescription();
+        if ($description !== '') {
+            $schema['description'] = $description;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Build a brand description for the Organization node so AI search
+     * engines have an explicit grounding for the brand entity. Prefers
+     * an admin-set "general/store_information/description" config; falls
+     * back to the head default description.
+     *
+     * Returns an empty string if no real description is configured. A
+     * synthesised phrase like "{name} — specialist retailer." is
+     * deliberately not used: it would be weighted by AI engines as a
+     * real description but adds no real information, which dilutes
+     * the Organization entity's GEO signal.
+     */
+    public function getOrganizationDescription(): string
+    {
+        $candidates = [
+            'general/store_information/description',
+            'design/head/default_description',
+        ];
+        foreach ($candidates as $path) {
+            $value = trim((string) ($this->getConfig($path) ?? ''));
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getWebsiteSchema(): array
+    {
+        $schema = [
+            '@type' => 'WebSite',
+            '@id' => $this->getWebsiteId(),
+            'url' => $this->getBaseUrl() . '/',
+            'name' => (string) ($this->getConfig('general/store_information/name') ?? ''),
+            'inLanguage' => $this->getStoreLocale(),
+            'publisher' => [
+                '@id' => $this->getOrganizationId(),
+            ],
+        ];
+
+        $search = $this->getSearchActionSchema();
+        if ($search) {
+            $schema['potentialAction'] = $search;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Build a SearchAction for WebSite.potentialAction (sitelinks searchbox).
+     * Returns [] when disabled or the search route is empty.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSearchActionSchema(): array
+    {
+        $target = $this->getBaseUrl() . '/catalogsearch/result/?q={search_term_string}';
+        return [
+            '@type' => 'SearchAction',
+            'target' => [
+                '@type' => 'EntryPoint',
+                'urlTemplate' => $target,
+            ],
+            'query-input' => 'required name=search_term_string',
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getSameAsUrls(): array
+    {
+        $urls = [];
+        $raw = (string) ($this->getConfig('structureddata/organization/sameas') ?? '');
+        foreach (preg_split('/\r\n|\r|\n/', $raw) ?: [] as $line) {
+            $line = trim((string) $line);
+            if ($line !== '' && filter_var($line, FILTER_VALIDATE_URL)) {
+                $urls[] = $line;
+            }
+        }
+
+        // Preserve the module's existing Related Pages setting while also
+        // supporting the newer one-URL-per-line setting.
+        try {
+            $relatedPages = $this->getConfig('structureddata/contact/related_pages');
+            if ($relatedPages) {
+                foreach ((array) $this->serializer->unserialize($relatedPages) as $page) {
+                    $url = is_array($page) ? trim((string) ($page['url'] ?? '')) : '';
+                    if ($url !== '' && filter_var($url, FILTER_VALIDATE_URL)) {
+                        $urls[] = $url;
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            // Ignore malformed legacy configuration.
+        }
+
+        return array_values(array_unique($urls));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBreadcrumbListSchema(): array
+    {
+        return [
+            '@type' => 'BreadcrumbList',
+            '@id' => $this->getBreadcrumbId(),
+            'itemListElement' => $this->getBreadcrumbItems(),
+        ];
+    }
+
+    /**
+     * Returns the visible breadcrumb items as ListItem entries. Reads the
+     * rendered breadcrumbs block where possible so the schema mirrors what
+     * the user sees.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getBreadcrumbItems(): array
+    {
+        $items = $this->resolveBreadcrumbItems();
+
+        $list = [];
+        $position = 1;
+        foreach ($items as $item) {
+            $list[] = [
+                '@type' => 'ListItem',
+                'position' => $position++,
+                'name' => $item['name'],
+                'item' => $item['url'],
+            ];
+        }
+
+        $list = $this->augmentBreadcrumbForCurrentPage($list);
+
+        return count($list) > 1 ? $list : [];
+    }
+
+    /**
+     * Ensure the BreadcrumbList JSON-LD always includes the current page as
+     * the final ListItem on Hub/Collection pages, even when the rendered
+     * Magento Breadcrumbs block only contains "Home". Without this, AI
+     * search engines cannot infer the relationship between the homepage and
+     * the deep category hub (e.g. /hub/surfboards).
+     *
+     * @param array<int, array<string, mixed>> $list
+     * @return array<int, array<string, mixed>>
+     */
+    private function augmentBreadcrumbForCurrentPage(array $list): array
+    {
+        if (!$this->shouldAugmentBreadcrumb()) {
+            return $list;
+        }
+
+        $currentUrl = $this->getCurrentUrl();
+        $currentName = $this->resolveCurrentBreadcrumbName();
+        if ($currentUrl === '' || $currentName === '') {
+            return $list;
+        }
+
+        $normalised = rtrim($currentUrl, '/');
+        foreach ($list as $entry) {
+            $entryUrl = (string) ($entry['item'] ?? '');
+            if ($entryUrl !== '' && rtrim($entryUrl, '/') === $normalised) {
+                return $list;
+            }
+        }
+
+        $nextPosition = 1;
+        foreach ($list as $entry) {
+            if (isset($entry['position']) && is_int($entry['position']) && $entry['position'] >= $nextPosition) {
+                $nextPosition = $entry['position'] + 1;
+            }
+        }
+
+        $list[] = [
+            '@type' => 'ListItem',
+            'position' => $nextPosition,
+            'name' => $currentName,
+            'item' => $currentUrl,
+        ];
+
+        return $list;
+    }
+
+    /**
+     * Augment the breadcrumb chain when on a Collection page so the JSON-LD
+     * always includes the current page as the final ListItem.
+     */
+    private function shouldAugmentBreadcrumb(): bool
+    {
+        return $this->isCollectionPage();
+    }
+
+    /**
+     * Resolve the human-readable name for the current breadcrumb tail.
+     * Prefers an explicit "page_title" data attr on this block, then the
+     * head/title.
+     */
+    private function resolveCurrentBreadcrumbName(): string
+    {
+        try {
+            $explicit = trim((string) $this->getData('page_title'));
+            if ($explicit !== '') {
+                return $explicit;
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        return trim((string) $this->getPageTitle());
+    }
+
+    /**
+     * Build a fallback main-entity ItemList for CollectionPage. Returns [] when the page
+     * is not a collection page or there are no items to list. Caller is
+     * responsible for omitting the field when this returns [].
+     *
+     * @return array<int, array<string, mixed>>|array<string, mixed>
+     */
+    public function getCollectionItemList(): array
+    {
+        // The category child block uses Magento's fully prepared ListProduct
+        // collection. An independent fallback cannot safely reproduce layers,
+        // permissions, sorting, stock filters, and pagination.
+        return [];
+    }
+
+    /**
+     * @return array<int, array{name: string, url: string}>
+     */
+    private function resolveBreadcrumbItems(): array
+    {
+        try {
+            $crumbs = $this->getCapturedCrumbs();
+            if (is_array($crumbs) && $crumbs) {
+                $items = [];
+                foreach ($crumbs as $crumb) {
+                    if (!is_array($crumb)) {
+                        continue;
+                    }
+                    $name = trim(strip_tags((string) ($crumb['label'] ?? '')));
+                    if ($name === '') {
+                        continue;
+                    }
+                    $url = (string) ($crumb['link'] ?? '');
+                    if ($url === '') {
+                        $url = $this->getCurrentUrl();
+                    }
+                    $items[] = ['name' => $name, 'url' => $this->normalizeUrl($url)];
+                }
+                if ($items) {
+                    return $items;
+                }
+            }
+        } catch (\Throwable $e) {
+            // Fall back to registry-derived breadcrumbs.
+        }
+
+        $items = $this->resolveFromRegistry();
+        if (!empty($items)) {
+            return $items;
+        }
+
+        // 3. Fallback: Home only.
+        return [
+            [
+                'name' => 'Home',
+                'url' => $this->getBaseUrl() . '/',
+            ],
+        ];
+    }
+
+    /**
+     * Returns crumbs captured by BreadcrumbsPlugin (preferred) or set via
+     * the module's own template bridge. Plugins run for any theme using
+     * the public Magento\Theme\Block\Html\Breadcrumbs block, so this works
+     * for Luma, Hyvä, and custom themes alike.
+     */
+    private function getCapturedCrumbs(): ?array
+    {
+        try {
+            $own = $this->getData('structured_data_crumbs');
+            if (is_array($own) && $own) {
+                return $own;
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+        try {
+            $layout = $this->getLayout();
+            $breadcrumbs = $layout ? $layout->getBlock('breadcrumbs') : null;
+            if ($breadcrumbs) {
+                $crumbs = $breadcrumbs->getData('crumbs');
+                if (is_array($crumbs) && $crumbs) {
+                    return $crumbs;
+                }
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+        return null;
+    }
+
+    /**
+     * Walk current_category / current_product in the registry to build a
+     * breadcrumb chain (Home + ancestors + current entity).
+     *
+     * On product pages, current_category is unreliable (it may be set to
+     * a brand-filter category from prior navigation), so we always use
+     * the product's own category assignments instead.
+     *
+     * @return array<int, array{name: string, url: string}>
+     */
+    private function resolveFromRegistry(): array
+    {
+        $items = [];
+
+        try {
+            $product = $this->registry->registry('current_product');
+            if ($product && is_object($product)) {
+                return $this->buildProductBreadcrumbItems($product);
+            }
+
+            $category = $this->registry->registry('current_category');
+            if ($category && is_object($category)) {
+                return $this->buildCategoryBreadcrumbItems($category);
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param \Magento\Catalog\Model\Category $category
+     * @return array<int, array{name: string, url: string}>
+     */
+    private function buildCategoryBreadcrumbItems($category): array
+    {
+        $items = [
+            [
+                'name' => 'Home',
+                'url' => $this->getBaseUrl() . '/',
+            ],
+        ];
+
+        try {
+            $path = (string) $category->getPath();
+            if ($path !== '') {
+                $ids = array_filter(array_map('intval', explode('/', $path)));
+                foreach ($ids as $id) {
+                    if ($id <= 2) {
+                        continue; // skip Roots
+                    }
+                    try {
+                        $cat = $this->categoryRepository->get($id, $this->getStore()->getId());
+                        if (!$cat->getId()) {
+                            continue;
+                        }
+                        $items[] = [
+                            'name' => (string) $cat->getName(),
+                            'url' => $this->normalizeUrl((string) $cat->getUrl()),
+                        ];
+                    } catch (\Throwable $e) {
+                        // skip missing ancestor
+                    }
+                }
+                return $items;
+            }
+
+            // No path attribute — emit Home + current category.
+            $items[] = [
+                'name' => (string) $category->getName(),
+                'url' => $this->normalizeUrl((string) $category->getUrl()),
+            ];
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param \Magento\Catalog\Model\Product $product
+     * @return array<int, array{name: string, url: string}>
+     */
+    private function buildProductBreadcrumbItems($product): array
+    {
+        $items = [
+            [
+                'name' => 'Home',
+                'url' => $this->getBaseUrl() . '/',
+            ],
+        ];
+
+        try {
+            $currentCategory = $this->registry->registry('current_category');
+            if ($currentCategory && in_array((int) $currentCategory->getId(), array_map('intval', $product->getCategoryIds()), true)) {
+                $items = $this->buildCategoryBreadcrumbItems($currentCategory);
+                $items[] = [
+                    'name' => (string) $product->getName(),
+                    'url' => $this->normalizeUrl((string) $product->getProductUrl()),
+                ];
+                return $items;
+            }
+
+            $categoryIds = (array) $product->getCategoryIds();
+            $categoryIds = array_values(array_filter(
+                array_map('intval', $categoryIds),
+                fn ($id) => $id > 2
+            ));
+            if (!empty($categoryIds)) {
+                // Pick the deepest active assigned category.
+                $bestId = 0;
+                $bestDepth = -1;
+                foreach ($categoryIds as $id) {
+                    try {
+                        $cat = $this->categoryRepository->get($id, $this->getStore()->getId());
+                    } catch (\Throwable $e) {
+                        continue;
+                    }
+                    if (!$cat->getId() || (method_exists($cat, 'getIsActive') && !$cat->getIsActive())) {
+                        continue;
+                    }
+                    $depth = substr_count((string) $cat->getPath(), '/');
+                    if ($depth > $bestDepth) {
+                        $bestDepth = $depth;
+                        $bestId = (int) $cat->getId();
+                    }
+                }
+
+                if ($bestId > 0) {
+                    try {
+                        $cat = $this->categoryRepository->get($bestId, $this->getStore()->getId());
+                        $path = (string) $cat->getPath();
+                        if ($path !== '') {
+                            $ids = array_filter(array_map('intval', explode('/', $path)));
+                            foreach ($ids as $id) {
+                                if ($id <= 2) {
+                                    continue;
+                                }
+                                try {
+                                    $c = $this->categoryRepository->get($id, $this->getStore()->getId());
+                                    if (!$c->getId() || (method_exists($c, 'getIsActive') && !$c->getIsActive())) {
+                                        continue;
+                                    }
+                                    $items[] = [
+                                        'name' => (string) $c->getName(),
+                                        'url' => $this->normalizeUrl((string) $c->getUrl()),
+                                    ];
+                                } catch (\Throwable $e) {
+                                    // skip
+                                }
+                            }
+                        }
+                    } catch (\Throwable $e) {
+                        // ignore
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        $items[] = [
+            'name' => (string) $product->getName(),
+            'url' => $this->normalizeUrl((string) $product->getProductUrl()),
+        ];
+
+        return $items;
+    }
+
+    public function normalizeUrl(string $url): string
+    {
+        $url = trim($url);
+        if ($url === '') {
+            return '';
+        }
+        if (str_starts_with($url, '/')) {
+            $url = $this->getBaseUrl() . '/' . ltrim($url, '/');
+        }
+        return preg_replace('/[?#].*$/', '', $url) ?: $url;
+    }
+
+    private function isPlaceholderUrl(string $url): bool
+    {
+        return stripos($url, '/placeholder/') !== false
+            || stripos($url, 'placeholder-image') !== false;
+    }
+
+    private function resolveFirstGalleryImageUrl(\Magento\Catalog\Model\Product $product): string
+    {
+        try {
+            $images = $product->getMediaGalleryImages();
+        } catch (\Throwable $e) {
+            return '';
+        }
+        if (!$images) {
+            return '';
+        }
+        try {
+            $mediaConfig = \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Catalog\Model\Product\Media\Config::class);
+        } catch (\Throwable $e) {
+            return '';
+        }
+        foreach ($images as $image) {
+            if (!is_object($image)) {
+                continue;
+            }
+            $file = (string) ($image->getData('file') ?? '');
+            if ($file === '' && method_exists($image, 'getFile')) {
+                $file = (string) $image->getFile();
+            }
+            if ($file === '' || $this->isPlaceholderUrl($file)) {
+                continue;
+            }
+            try {
+                return (string) $mediaConfig->getMediaUrl($file);
+            } catch (\Throwable $e) {
+                return '';
+            }
+        }
+        return '';
+    }
+
+    public function encodeJson(array $payload): string
+    {
+        $json = json_encode(
+            $payload,
+            JSON_UNESCAPED_SLASHES
+            | JSON_UNESCAPED_UNICODE
+            | JSON_HEX_TAG
+            | JSON_HEX_AMP
+            | JSON_HEX_APOS
+            | JSON_HEX_QUOT
+            | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+        return is_string($json) ? $json : '';
+    }
+
+    /**
+     * Extra @graph nodes contributed by site modules (plugins).
+     *
+     * Override via afterGetExtraGraphNodes to append entities such as
+     * FAQPage without scraping the rendered JSON-LD HTML.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getExtraGraphNodes(): array
+    {
+        return [];
+    }
+
+    /**
+     * Allow site modules to augment the page entity before it is pushed
+     * into @graph (e.g. link the page to an FAQPage via about: {@id}).
+     *
+     * @param array<string, mixed> $pageEntity
+     * @return array<string, mixed>
+     */
+    public function extendPageEntity(array $pageEntity): array
+    {
+        return $pageEntity;
     }
 }

--- a/Block/Product.php
+++ b/Block/Product.php
@@ -71,6 +71,8 @@ class Product extends View
 
     public function getSchemaJson()
     {
-        return json_encode($this->_productData->getSchemaData($this->getProduct()), JSON_UNESCAPED_SLASHES);
+        $schema = $this->_productData->getSchemaData($this->getProduct());
+        $encoded = json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        return is_string($encoded) ? $encoded : '';
     }
 }

--- a/Model/Config/Source/ReturnMethod.php
+++ b/Model/Config/Source/ReturnMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OuterEdge\StructuredData\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class ReturnMethod implements OptionSourceInterface
+{
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => '', 'label' => __('Unspecified')],
+            ['value' => 'ReturnByMail', 'label' => __('Return by mail')],
+            ['value' => 'ReturnInStore', 'label' => __('Return in store')],
+            ['value' => 'ReturnAtKiosk', 'label' => __('Return at kiosk')],
+        ];
+    }
+}

--- a/Model/Resolver/Product/StructuredData.php
+++ b/Model/Resolver/Product/StructuredData.php
@@ -55,6 +55,9 @@ class StructuredData implements ResolverInterface
         /** @var ProductInterface $product */
         $product = $value['model'];
 
-        return json_encode($this->productData->getSchemaData($product), JSON_UNESCAPED_SLASHES);
+        $schema = $this->productData->getSchemaData($product);
+        $encoded = json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+
+        return is_string($encoded) ? $encoded : '';
     }
 }

--- a/Model/Type/Product.php
+++ b/Model/Type/Product.php
@@ -21,10 +21,9 @@ use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Catalog\Model\Product\Visibility;
-use Magento\Framework\App\CacheInterface;
-use Magento\Framework\Serialize\SerializerInterface;
-use OuterEdge\StructuredData\Model\Cache\Type\StructuredDataCache;
 use Magento\Framework\View\Element\Template;
+use Magento\Framework\Registry;
+use Magento\Catalog\Api\CategoryRepositoryInterface;
 
 class Product
 {
@@ -99,22 +98,22 @@ class Product
         protected PricingHelper $pricingHelper,
         protected TaxHelper $taxHelper,
         protected ProductRepositoryInterface $productRepository,
-        protected CacheInterface $cache,
-        protected SerializerInterface $serializer,
-        protected Template $template
+        protected Template $template,
+        protected Registry $registry,
+        protected CategoryRepositoryInterface $categoryRepository
 	) {
 	}
 
     public function getSchemaData(ProductModel $product)
     {
-        if (!$this->_product) {
-            $this->_product = $product;
-        }
+        $this->resetProductState();
+        $this->_product = $product;
 
         $data = [
             "@context" => "https://schema.org/",
             "@type" => "Product",
-            "@id" => $this->escapeUrl(strtok($this->_product->getUrlInStore(), '?'))."#Product",
+            "@id" => $this->getCanonicalProductUrl($this->_product)."#Product",
+            "url" => $this->getCanonicalProductUrl($this->_product),
             "name" => $this->escapeQuote((string)strip_tags($this->_product->getName())),
             "sku" => $this->escapeQuote((string)strip_tags($this->_product->getSku())),
             "description" => $this->escapeHtml((string)$this->template->stripTags($this->getDescription())),
@@ -177,8 +176,20 @@ class Product
             }
         }
 
-        if ($this->getGtin()) {
-            $data['gtin'] = $this->escapeQuote((string)strip_tags($this->getGtin()));
+        if ($gtin = trim((string) strip_tags((string) $this->getGtin()))) {
+            $normalizedGtin = preg_replace('/\D/', '', $gtin) ?: '';
+            $len = strlen($normalizedGtin);
+            $key = match (true) {
+                $len === 8 => 'gtin8',
+                $len === 12 => 'gtin12',
+                $len === 13 => 'gtin13',
+                $len === 14 => 'gtin14',
+                default => 'gtin',
+            };
+            $data['gtin'] = $this->escapeQuote($gtin);
+            if ($key !== 'gtin' && preg_match('/^[\d\s-]+$/', $gtin)) {
+                $data[$key] = $normalizedGtin;
+            }
         }
 
         if ($this->getMpn()) {
@@ -189,16 +200,18 @@ class Product
             $data['isbn'] = $this->escapeQuote((string)strip_tags($this->getIsbn()));
         }
 
-        if ($this->getSize()) {
-            $data['size'] = $this->escapeQuote((string)strip_tags($this->getSize()));
+        if ($size = $this->getSize()) {
+            $data['size'] = $this->escapeQuote((string) strip_tags($size));
+        }
+        if ($color = $this->getColor()) {
+            $data['color'] = $this->escapeQuote((string) strip_tags($color));
+        }
+        if ($material = $this->getMaterial()) {
+            $data['material'] = $this->escapeQuote((string) strip_tags($material));
         }
 
-        if ($this->getMaterial()) {
-            $data['material'] = $this->escapeQuote((string)strip_tags($this->getMaterial()));
-        }
-
-        if ($this->getColor()) {
-            $data['color'] = $this->escapeQuote((string)strip_tags($this->getColor()));
+        if ($category = $this->getProductCategory()) {
+            $data['category'] = $category;
         }
 
         if ($this->getKeywords()) {
@@ -244,6 +257,7 @@ class Product
             return null;
         }
 
+        $this->resetProductState();
         $this->_product = $product;
 
         $children = $this->getChildren();
@@ -265,7 +279,7 @@ class Product
                 $offers[$key]['sku'] = $_childProduct->getSku();
 
                 if ($_childProduct->getVisibility() == Visibility::VISIBILITY_NOT_VISIBLE) {
-                    $offers[$key]['url'] = $this->_product->getProductUrl();
+                    $offers[$key]['url'] = $this->getCanonicalProductUrl($this->_product);
                 }
                 $key == $lastKey ? '' : ',';
             }
@@ -305,9 +319,6 @@ class Product
         if ($this->getConfig('structureddata/product/hide_price')) {
             return null;
         }
-        if ($result = $this->getCache($product->getId())) {
-            return $result;
-        }
 
         $availability      = 'OutOfStock';
         $product           = $this->productRepository->getById($product->getId());
@@ -331,12 +342,17 @@ class Product
 
         $data = [
             "@type" => "Offer",
-            "url" => $this->escapeUrl(strtok($product->getUrlInStore(), '?')),
+            "url" => $this->getCanonicalProductUrl($product),
             "price" => $this->escapeQuote((string)$this->pricingHelper->currency($finalPriceWithTax, false, false)),
             "priceCurrency" => $this->escapeQuote($this->getStore()->getCurrentCurrency()->getCode()),
             "availability" => "http://schema.org/$availability",
             "itemCondition" => "http://schema.org/NewCondition"
         ];
+
+        $returnPolicy = $this->getMerchantReturnPolicy();
+        if ($returnPolicy !== []) {
+            $data['hasMerchantReturnPolicy'] = $returnPolicy;
+        }
 
         if ($product->getFinalPrice() < $product->getPrice()) {
             if ($product->getSpecialToDate()) {
@@ -353,7 +369,6 @@ class Product
             ];
         }
 
-        $this->saveCache($product->getId(), $data);
         return $data;
     }
 
@@ -481,7 +496,87 @@ class Product
      */
     public function getImageUrl($product, $imageId)
     {
-        return $this->imageHelper->init($product, $imageId)->getUrl();
+        $url = (string) $this->imageHelper->init($product, $imageId)->getUrl();
+        if ($url !== '' && !$this->isPlaceholderUrl($url)) {
+            return $url;
+        }
+
+        // Fallback: the product has no role-attribute image set; the
+        // catalog helper therefore returns the placeholder. Try the
+        // other common image roles, then the media gallery.
+        foreach (['product_page_image_large', 'product_page_image_medium', 'product_base_image', 'image'] as $candidate) {
+            if ($candidate === $imageId) {
+                continue;
+            }
+            try {
+                $candidateUrl = (string) $this->imageHelper->init($product, $candidate)->getUrl();
+            } catch (\Throwable $e) {
+                continue;
+            }
+            if ($candidateUrl !== '' && !$this->isPlaceholderUrl($candidateUrl)) {
+                return $candidateUrl;
+            }
+        }
+
+        $galleryUrl = $this->resolveFirstGalleryImageUrl($product);
+        if ($galleryUrl !== '') {
+            return $galleryUrl;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Use the first media-gallery entry when the product's role
+     * attributes (image / small_image / thumbnail) are unset. Many
+     * products only carry media-gallery attachments, so without this
+     * fallback the structured-data `image` would be the catalog
+     * placeholder, which AI search engines and Google Shopping ignore.
+     */
+    private function resolveFirstGalleryImageUrl(\Magento\Catalog\Model\Product $product): string
+    {
+        try {
+            $images = $product->getMediaGalleryImages();
+        } catch (\Throwable $e) {
+            return '';
+        }
+        if (!$images) {
+            return '';
+        }
+        try {
+            $mediaConfig = ObjectManager::getInstance()
+                ->get(\Magento\Catalog\Model\Product\Media\Config::class);
+        } catch (\Throwable $e) {
+            return '';
+        }
+        foreach ($images as $image) {
+            if (!is_object($image)) {
+                continue;
+            }
+            // `getMediaGalleryImages()` returns a collection of
+            // `Magento\Framework\DataObject` items. Some Magento
+            // distributions wrap those in `Image` instances, so accept
+            // either and read the underlying `file` data value.
+            $file = (string) ($image->getData('file') ?? '');
+            if ($file === '' && method_exists($image, 'getFile')) {
+                $file = (string) $image->getFile();
+            }
+            if ($file === '' || $this->isPlaceholderUrl($file)) {
+                continue;
+            }
+            try {
+                return (string) $mediaConfig->getMediaUrl($file);
+            } catch (\Throwable $e) {
+                return '';
+            }
+        }
+        return '';
+    }
+
+    private function isPlaceholderUrl(string $url): bool
+    {
+        return stripos($url, '/placeholder/') !== false
+            || stripos($url, 'placeholder-image') !== false;
     }
 
     public function getAttributeText($attribute)
@@ -663,33 +758,127 @@ class Product
      */
     public function escapeHtml($data, $allowedTags = null)
     {
-        return $this->_escaper->escapeHtml($data, $allowedTags);
+        return trim(strip_tags((string) $data));
     }
 
     public function escapeQuote($data)
     {
-        return htmlspecialchars($data, ENT_QUOTES | ENT_SUBSTITUTE, null, false);
+        return (string) $data;
     }
     
-    protected function getCacheId($productId)
+    /**
+     * Returns the configured MerchantReturnPolicy, or an empty array when no
+     * return window has been configured. The module must not invent a policy.
+     *
+     * @return array<string, mixed>
+     */
+    public function getMerchantReturnPolicy(): array
     {
-        return StructuredDataCache::TYPE_IDENTIFIER . '_' . $this->getStore()->getId() . '_' . $productId;
-    }
-
-    protected function saveCache($productId, $data)
-    {
-        $this->cache->save(
-            $this->serializer->serialize($data),
-            $this->getCacheId($productId),
-            [StructuredDataCache::CACHE_TAG]
-        );
-    }
-
-    protected function getCache($productId)
-    {
-        if ($result = $this->cache->load($this->getCacheId($productId))) {
-            return $this->serializer->unserialize($result);
+        $days = (int) $this->getConfig('structureddata/shipping_return/merchant_return_days');
+        if ($days <= 0) {
+            return [];
         }
-        return false;
+
+        $policy = [
+            '@type' => 'MerchantReturnPolicy',
+            'returnPolicyCategory' => 'https://schema.org/MerchantReturnFiniteReturnWindow',
+            'merchantReturnDays' => $days,
+        ];
+
+        $method = trim((string) $this->getConfig('structureddata/shipping_return/return_method'));
+        if (in_array($method, ['ReturnByMail', 'ReturnInStore', 'ReturnAtKiosk'], true)) {
+            $policy['returnMethod'] = 'https://schema.org/' . $method;
+        }
+
+        return $policy;
     }
+
+    /**
+     * Returns the deepest user-facing category assigned to the product as
+     * a schema.org Thing entity (with @id, @type, name, and url) so AI
+     * search engines can both label and link to the category page.
+     *
+     * Uses the product's own category assignments and skips inactive
+     * categories. The current category is deliberately not preferred because
+     * it can represent a navigation/filter context rather than taxonomy.
+     *
+     * @return array<string, mixed>
+     */
+    public function getProductCategory(): string
+    {
+        $currentCategory = $this->registry->registry('current_category');
+        $assignedIds = array_map('intval', (array) $this->_product->getCategoryIds());
+        if ($currentCategory && in_array((int) $currentCategory->getId(), $assignedIds, true)) {
+            return $this->escapeQuote((string) $currentCategory->getName());
+        }
+
+        $ids = array_values(array_filter($assignedIds, fn ($id) => $id > 2));
+        if (empty($ids)) {
+            return '';
+        }
+
+        try {
+            $bestCategory = null;
+            $bestDepth = -1;
+            foreach ($ids as $id) {
+                try {
+                    $cat = $this->categoryRepository->get($id, $this->getStore()->getId());
+                } catch (\Throwable $e) {
+                    continue;
+                }
+                if (!$cat->getId()
+                    || (method_exists($cat, 'getIsActive') && !$cat->getIsActive())
+                ) {
+                    continue;
+                }
+                $depth = substr_count((string) $cat->getPath(), '/');
+                if ($depth > $bestDepth) {
+                    $bestDepth = $depth;
+                    $bestCategory = $cat;
+                }
+            }
+            return $bestCategory ? $this->escapeQuote((string) $bestCategory->getName()) : '';
+        } catch (\Throwable $e) {
+            return '';
+        }
+    }
+
+    private function getCanonicalProductUrl(ProductModel $product): string
+    {
+        $url = $this->resolveCategoryIndependentProductUrl($product);
+        $url = preg_replace('/[?#].*$/', '', $url) ?: $url;
+        return $this->escapeUrl(strip_tags($url));
+    }
+
+    private function resolveCategoryIndependentProductUrl(ProductModel $product): string
+    {
+        try {
+            $urlModel = $product->getUrlModel();
+            if ($urlModel && method_exists($urlModel, 'getUrl')) {
+                $url = (string) $urlModel->getUrl($product, [
+                    '_ignore_category' => true,
+                    '_scope_to_url' => true,
+                ]);
+                if ($url !== '') {
+                    return $url;
+                }
+            }
+        } catch (\Throwable $e) {
+            // Fall back to the product URL API below.
+        }
+        return (string) $product->getProductUrl(false);
+    }
+
+    private function resetProductState(): void
+    {
+        $this->brand = null;
+        $this->weight = null;
+        $this->minWeight = null;
+        $this->maxWeight = null;
+        $this->minPrice = null;
+        $this->maxPrice = null;
+        $this->reviewsCount = null;
+        $this->_reviewData = null;
+    }
+
 }

--- a/Plugin/Theme/Block/Html/BreadcrumbsPlugin.php
+++ b/Plugin/Theme/Block/Html/BreadcrumbsPlugin.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace OuterEdge\StructuredData\Plugin\Theme\Block\Html;
+
+use Magento\Theme\Block\Html\Breadcrumbs as Subject;
+
+/**
+ * Captures crumbs whenever the standard Magento breadcrumbs block is
+ * populated, regardless of the template (Luma, Hyvä, or any theme that
+ * uses the public addCrumb() API). The captured array is exposed on the
+ * structured data block so the unified @graph BreadcrumbList mirrors the
+ * visible navigation trail.
+ */
+class BreadcrumbsPlugin
+{
+    public function afterAddCrumb(
+        Subject $subject,
+        $result,
+        $crumbName,
+        $crumbInfo
+    ) {
+        $crumbs = $subject->getData('structured_data_crumbs');
+        if (!is_array($crumbs)) {
+            $crumbs = [];
+        }
+        $crumbs[$crumbName] = is_array($crumbInfo) ? $crumbInfo : [];
+        $subject->setData('structured_data_crumbs', $crumbs);
+        return $result;
+    }
+
+    public function afterToHtml(Subject $subject, string $result): string
+    {
+        $this->captureCrumbs($subject);
+        return $result;
+    }
+
+    private function captureCrumbs(Subject $subject): void
+    {
+        try {
+            $crumbs = $subject->getData('structured_data_crumbs');
+            if (!is_array($crumbs) || !$crumbs) {
+                return;
+            }
+
+            $layout = $subject->getLayout();
+            if (!$layout) {
+                return;
+            }
+
+            $jsonld = $layout->getBlock('structured.data.jsonld');
+            if ($jsonld === null) {
+                return;
+            }
+
+            $existing = $jsonld->getData('structured_data_crumbs');
+            if (is_array($existing) && $existing) {
+                return;
+            }
+
+            $jsonld->setData('structured_data_crumbs', $crumbs);
+        } catch (\Throwable $e) {
+            // never break rendering for telemetry
+        }
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -124,6 +124,26 @@
                     <label>Keywords attribute code</label>
                 </field>
             </group>
+            <group id="organization" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Organization (GEO)</label>
+                <field id="sameas" translate="label" type="textarea" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Social / External profile URLs (sameAs)</label>
+                    <comment>One URL per line. Populates the Organization entity's sameAs array for GEO/AI entity grounding (Wikipedia, Wikidata, LinkedIn, Trustpilot, etc.).</comment>
+                </field>
+            </group>
+            <group id="shipping_return" translate="label" type="text" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Shipping &amp; Returns (GEO)</label>
+                <field id="merchant_return_days" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Default return window (days)</label>
+                    <comment>Used to emit MerchantReturnPolicy on Product Offer entities. Set to 0 to omit return-policy markup.</comment>
+                    <validate>validate-digits validate-zero-or-greater</validate>
+                </field>
+                <field id="return_method" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Return method</label>
+                    <source_model>OuterEdge\StructuredData\Model\Config\Source\ReturnMethod</source_model>
+                    <comment>Leave unspecified unless this method applies to the configured return policy.</comment>
+                </field>
+            </group>
             <group id="cms" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>CMS Pages</label>
                 <field id="enable" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,6 +14,13 @@
                 <type>Organization</type>
                 <enable_home>1</enable_home>
             </contact>
+            <organization>
+                <sameas></sameas>
+            </organization>
+            <shipping_return>
+                <merchant_return_days>0</merchant_return_days>
+                <return_method></return_method>
+            </shipping_return>
         </structureddata>
     </default>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -9,6 +9,9 @@
     <type name="Magento\Framework\App\Cache">
         <plugin name="flush_structured_data_cache" type="OuterEdge\StructuredData\Plugin\Cache\FlushStructuredDataCache"/>
     </type>
+    <type name="Magento\Theme\Block\Html\Breadcrumbs">
+        <plugin name="OuterEdge_StructuredData::captureBreadcrumbs" type="OuterEdge\StructuredData\Plugin\Theme\Block\Html\BreadcrumbsPlugin"/>
+    </type>
 
     <!--API-->
     <preference for="OuterEdge\StructuredData\Api\OffersRepositoryInterface" type="OuterEdge\StructuredData\Model\Api\OffersRepository"/>

--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <!-- Move markup to end of category page to avoid loading entire product collection -->
-        <move element="structured.data.jsonld" destination="before.body.end" after="-" />
-
         <referenceBlock name="structured.data.jsonld">
             <block ifconfig="structureddata/product/enable_category" class="OuterEdge\StructuredData\Block\Category" name="main.entity" template="OuterEdge_StructuredData::jsonld/schema.phtml" />
         </referenceBlock>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -30,6 +30,10 @@
                 <argument name="zone" xsi:type="boolean">false</argument>
             </arguments>
         </referenceBlock>
-        <referenceBlock name="breadcrumbs" template="Magento_Catalog::product/breadcrumbs.phtml"/>
+        <referenceBlock name="breadcrumbs" template="Magento_Catalog::product/breadcrumbs.phtml">
+            <arguments>
+                <argument name="skip_ld_json_schema" xsi:type="boolean">true</argument>
+            </arguments>
+        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceBlock name="head.additional">
+        <referenceContainer name="before.body.end">
             <block class="OuterEdge\StructuredData\Block\Jsonld" name="structured.data.jsonld" template="OuterEdge_StructuredData::jsonld.phtml"/>
-        </referenceBlock>
+        </referenceContainer>
         <referenceBlock name="breadcrumbs" template="OuterEdge_StructuredData::html/breadcrumbs.phtml"/>
     </body>
 </page>

--- a/view/frontend/layout/hyva_default.xml
+++ b/view/frontend/layout/hyva_default.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceBlock name="breadcrumbs" template="Magento_Theme::html/breadcrumbs.phtml"/>
+        <referenceBlock name="breadcrumbs" template="Magento_Theme::html/breadcrumbs.phtml">
+            <arguments>
+                <argument name="skip_ld_json_schema" xsi:type="boolean">true</argument>
+            </arguments>
+        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/templates/html/breadcrumbs.phtml
+++ b/view/frontend/templates/html/breadcrumbs.phtml
@@ -1,4 +1,5 @@
 <?php if ($crumbs && is_array($crumbs)): ?>
+    <?php $block->setData('structured_data_crumbs', $crumbs); ?>
 <div class="breadcrumbs">
     <ul class="items">
         <?php foreach ($crumbs as $crumbName => $crumbInfo): ?>
@@ -19,26 +20,10 @@
 </div>
 <?php endif; ?>
 
-
-<?php if ($crumbs && is_array($crumbs)): ?>
-<script type="application/ld+json">
-{
-    <?php $position = 1; ?>
-    "@context": "http://schema.org",
-    "@type": "BreadcrumbList",
-    "itemListElement": [
-    <?php foreach ($crumbs as $crumbName => $crumbInfo): ?>
-    {
-            "@type": "ListItem",
-            "position": "<?= $escaper->escapeHtml($position++) ?>",
-            "item": {
-                "@id": "<?= $escaper->escapeUrl($crumbInfo['link']) ?>",
-                "name": "<?= $escaper->escapeHtml($crumbInfo['label']) ?>"
-            }
-    }
-        <?= $crumbInfo['last'] ? '' : ',' ?>
-    <?php endforeach; ?>
-    ]
-}
-</script>
-<?php endif; ?>
+<?php
+// NOTE: BreadcrumbList JSON-LD is now emitted server-side by the outer/edge
+// structured-data module inside the unified @graph block on every page
+// (id="structured-data"). The previous inline <script type="application/ld+json">
+// emission here was removed to prevent duplicate BreadcrumbList nodes per
+// GEO plan (Issue 8).
+?>

--- a/view/frontend/templates/jsonld.phtml
+++ b/view/frontend/templates/jsonld.phtml
@@ -1,42 +1,157 @@
 <!-- Structured Data by outer/edge (https://outeredge.agency) -->
 <?php
 /** @var \OuterEdge\StructuredData\Block\Jsonld $block */
-$mainEntity = $block->getChildHtml('main.entity');
-$additionalSchema = $block->getChildHtml('additional.schema');
-$isWebsite = $block->getPageType() === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE;
-$storeName = (string) ($block->getConfig('general/store_information/name') ?? '');
-$baseUrl = $block->getStore()->getBaseUrl();
-$logoUrl = (string) ($block->getStoreLogoUrl() ?? '');
-?>
-<script type="application/ld+json" id="structured-data">
-{
-    "@context": "https://schema.org/",
-    "@type": "<?= $block->escapeQuote($block->getPageType()) ?>"
-    <?php if ($isWebsite): ?>
-    ,"url": <?= /* @noEscape */ json_encode($baseUrl, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>
-    ,"name": <?= /* @noEscape */ json_encode($storeName, JSON_UNESCAPED_UNICODE); ?>
-    <?php endif; ?>
-    ,"publisher": {
-        "@type": "Organization",
-        "name": <?= /* @noEscape */ json_encode($storeName, JSON_UNESCAPED_UNICODE); ?>,
-        "url": <?= /* @noEscape */ json_encode($baseUrl, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>,
-        "logo": {
-            "@type": "ImageObject",
-            "url": <?= /* @noEscape */ json_encode($logoUrl, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>
+
+$mainEntityJson = $block->getChildHtml('main.entity');
+$additionalSchemaJson = $block->getChildHtml('additional.schema');
+$organization = $block->getOrganizationSchema();
+$website = $block->getWebsiteSchema();
+$graph = [];
+
+$pageType = $block->getPageType();
+
+// Merge the richer home/contact organization payload into the canonical node.
+if (trim($mainEntityJson) !== '' && in_array($pageType, [
+    \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE,
+    \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_CONTACTPAGE,
+], true)) {
+    $decodedOrganization = json_decode($mainEntityJson, true);
+    if (is_array($decodedOrganization)) {
+        unset($decodedOrganization['@context']);
+        $sameAs = array_values(array_unique(array_merge(
+            (array) ($organization['sameAs'] ?? []),
+            (array) ($decodedOrganization['sameAs'] ?? [])
+        )));
+        $organization = array_replace($organization, $decodedOrganization);
+        if ($sameAs) {
+            $organization['sameAs'] = $sameAs;
+        }
+        $organization['@id'] = $block->getOrganizationId();
+    }
+}
+
+$graph[] = $organization;
+$graph[] = $website;
+
+// The homepage is represented by the canonical WebSite node above. Other
+// routes get a separate page entity.
+$pageEntity = [
+    '@type' => $pageType,
+    '@id' => $block->getPageId(),
+    'url' => $block->getCurrentUrl(),
+    'name' => $block->getPageTitle(),
+    'inLanguage' => $block->getStoreLocale(),
+    'isPartOf' => ['@id' => $block->getWebsiteId()],
+    'publisher' => ['@id' => $block->getOrganizationId()],
+    'breadcrumb' => ['@id' => $block->getBreadcrumbId()],
+];
+
+$description = $block->getPageDescription();
+if ($description !== '') {
+    $pageEntity['description'] = $description;
+}
+
+$dateModified = $block->getPageDateModified();
+if ($dateModified !== '') {
+    $pageEntity['dateModified'] = $dateModified;
+}
+
+$primaryImage = $block->getPagePrimaryImage();
+if (!empty($primaryImage)) {
+    $pageEntity['primaryImageOfPage'] = $primaryImage;
+}
+
+// CMS metadata is not merged into the homepage WebSite entity. Master keeps
+// the homepage WebSite valid and renders Organization separately.
+if (trim($additionalSchemaJson) !== '') {
+    $decoded = json_decode($additionalSchemaJson, true);
+    if (is_array($decoded) && $pageType !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE) {
+        foreach ($decoded as $key => $value) {
+            if ($key === '@type' && is_string($value)) {
+                // Preserve array form for CollectionPage.
+                if (is_array($pageEntity['@type'])) {
+                    if (!in_array($value, $pageEntity['@type'], true)) {
+                        $pageEntity['@type'][] = $value;
+                    }
+                } else {
+                    $pageEntity['@type'] = $value;
+                }
+                continue;
+            }
+            $pageEntity[$key] = $value;
         }
     }
-    <?php if ($mainEntity && !$isWebsite): ?>
-    ,
-    "mainEntity": <?= /* @noEscape */ $mainEntity; ?>
-    <?php endif; ?>
-    <?php if ($additionalSchema): ?>
-        <?= /* @noEscape */ $additionalSchema; ?>
-    <?php endif; ?>
 }
-</script>
-<?php if ($isWebsite && $mainEntity): ?>
-<script type="application/ld+json" id="structured-data-organization">
-<?= /* @noEscape */ $mainEntity; ?>
-</script>
+
+// Product and category children provide the page's main entity.
+if (trim($mainEntityJson) !== '' && !in_array($pageType, [
+    \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE,
+    \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_CONTACTPAGE,
+], true)) {
+    $decoded = json_decode($mainEntityJson, true);
+    if (is_array($decoded)) {
+        unset($decoded['@context']);
+        if (isset($decoded['mainEntity'])) {
+            $pageEntity['mainEntity'] = $decoded['mainEntity'];
+        } elseif (($decoded['@type'] ?? null) === 'ItemList') {
+            $pageEntity['mainEntity'] = $decoded;
+        } elseif (isset($decoded['itemListElement'])) {
+            // Bare ItemList shape.
+            $pageEntity['mainEntity'] = [
+                '@type' => 'ItemList',
+                'itemListElement' => $decoded['itemListElement'],
+            ];
+        } elseif (isset($decoded['@type']) && $decoded['@type'] === 'Product') {
+            // Product block emits a flat Product entity (name, sku, image,
+            // brand, offers, etc.) without a wrapper. Append it to the graph
+            // and link the page entity via mainEntity so the existing offers
+            // merger (which targets mainEntity.offers) keeps working.
+            $pageEntity['mainEntity'] = ['@id' => $decoded['@id'] ?? ''];
+            $graph[] = $decoded;
+        }
+    }
+}
+
+if ($block->isCollectionPage() && !isset($pageEntity['mainEntity'])) {
+    $itemList = $block->getCollectionItemList();
+    if (!empty($itemList)) {
+        $pageEntity['mainEntity'] = $itemList;
+    }
+}
+
+if ($pageType === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_CONTACTPAGE) {
+    $pageEntity['mainEntity'] = ['@id' => $block->getOrganizationId()];
+}
+
+// Site modules may augment the page entity (e.g. about → FAQPage) and
+// contribute additional @graph nodes via plugins on these public methods.
+$pageEntity = $block->extendPageEntity($pageEntity);
+
+// Only emit the BreadcrumbList when there's at least one item.
+$breadcrumbItems = $block->getBreadcrumbItems();
+if ($pageType !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE && !empty($breadcrumbItems)) {
+    $graph[] = $block->getBreadcrumbListSchema();
+} else {
+    unset($pageEntity['breadcrumb']);
+}
+
+if ($pageType !== \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE) {
+    $graph[] = $pageEntity;
+}
+
+foreach ($block->getExtraGraphNodes() as $extraNode) {
+    if (is_array($extraNode) && $extraNode !== []) {
+        $graph[] = $extraNode;
+    }
+}
+
+$payload = [
+    '@context' => 'https://schema.org/',
+    '@graph' => $graph,
+];
+?>
+<?php $encodedPayload = $block->encodeJson($payload); ?>
+<?php if ($encodedPayload !== ''): ?>
+<script type="application/ld+json" id="structured-data"><?= /* @noEscape */ $encodedPayload ?></script>
 <?php endif; ?>
 <?= $block->getChildHtml('product.offers.schema'); ?>

--- a/view/frontend/templates/jsonld/cms.phtml
+++ b/view/frontend/templates/jsonld/cms.phtml
@@ -1,23 +1,28 @@
 <?php
 /** @var \OuterEdge\StructuredData\Block\Cms $block */
-// Homepage is typed as WebSite; CMS-page properties belong on WebPage only.
 if ($block->getPageType() === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_WEBSITE) {
     return;
 }
-?>
-,"name": <?= /* @noEscape */ json_encode((string) $block->stripTags($block->getTitle()), JSON_UNESCAPED_UNICODE); ?>
-<?php $content = trim((string) $block->stripTags($block->getContent())); ?>
-<?php if ($content): ?>
-,"mainContentOfPage": {
-    "text": <?= /* @noEscape */ json_encode($content, JSON_UNESCAPED_UNICODE); ?>
+
+$payload = [
+    '@type' => $block->getPageType() === \OuterEdge\StructuredData\Block\Jsonld::PAGE_TYPE_ABOUTPAGE
+        ? 'AboutPage'
+        : 'WebPage',
+    'name' => strip_tags($block->getTitle()),
+];
+$content = $block->getContent();
+if ($content) {
+    $payload['mainContentOfPage'] = [
+        'text' => strip_tags($content),
+    ];
 }
-<?php endif; ?>
-<?php if ($block->getMetaDescription()): ?>
-    ,"description": <?= /* @noEscape */ json_encode(preg_replace('/\s+/', ' ', trim($block->stripTags($block->getMetaDescription()))), JSON_UNESCAPED_UNICODE); ?>
-<?php endif; ?>
-<?php if ($block->getImage()): ?>
-    ,"primaryImageOfPage": {
-        "@type": "ImageObject",
-        "url": <?= /* @noEscape */ json_encode((string) $block->getImage(), JSON_UNESCAPED_UNICODE); ?>
-    }
-<?php endif; ?>
+if ($block->getMetaDescription()) {
+    $payload['description'] = preg_replace('/\s+/', ' ', trim(strip_tags($block->getMetaDescription())));
+}
+if ($block->getImage()) {
+    $payload['primaryImageOfPage'] = [
+        '@type' => 'ImageObject',
+        'url' => $block->getImage(),
+    ];
+}
+echo $block->encodeJson($payload);

--- a/view/frontend/templates/jsonld/product-offers.phtml
+++ b/view/frontend/templates/jsonld/product-offers.phtml
@@ -1,20 +1,48 @@
 <?php
     $product = $block->getProduct();
     if ($product && $product->getEntityId()):
+        $productSchema = $block->getSchemaJson();
+        $productData = json_decode((string) $productSchema, true);
+        $productId = is_array($productData) ? (string) ($productData['@id'] ?? '') : '';
 ?>
 <script async>
     function fetchOffersSchema(ID) {
         fetch(window.BASE_URL + 'rest/V1/structure_data/offers/' + ID)
         .then(response => response.json())
         .then((data) => {
-            if (!data.length && !data[0].offers) return;
+            if (!Array.isArray(data) || !data.length || !data[0] || !data[0].offers) return;
 
             const structuredData = document.getElementById('structured-data');
             if (!structuredData) return;
 
-            const structuredDataJson = JSON.parse(structuredData.textContent);
-            structuredDataJson.mainEntity.offers = data[0].offers;
-            structuredData.textContent = JSON.stringify(structuredDataJson);
+            let structuredDataJson;
+            try {
+                structuredDataJson = JSON.parse(structuredData.textContent);
+            } catch (e) {
+                return;
+            }
+            const offers = data[0].offers;
+            const targetId = '<?= $escaper->escapeJs($productId) ?>';
+
+            function applyOffers(node) {
+                if (!node) return false;
+                node.offers = offers;
+                return true;
+            }
+
+            // Only update the Product entity requested by this page. A type
+            // fallback can corrupt another extension's Product node.
+            if (targetId && Array.isArray(structuredDataJson['@graph'])) {
+                const target = structuredDataJson['@graph'].find(
+                    (n) => n && n['@id'] === targetId
+                );
+                if (applyOffers(target)) {
+                    structuredData.textContent = JSON.stringify(structuredDataJson);
+                    return;
+                }
+            }
+        }).catch(() => {
+            // intentionally swallow - initial HTML must remain valid
         });
     }
 
@@ -26,6 +54,6 @@
         }
     }
 
-    waitForBaseUrl(() => fetchOffersSchema('<?= $block->escapeQuote($product->getEntityId()) ?>'));
+    waitForBaseUrl(() => fetchOffersSchema('<?= $escaper->escapeJs((string) $product->getEntityId()) ?>'));
 </script>
 <?php endif; ?>

--- a/view/frontend/templates/jsonld/product-offers.phtml
+++ b/view/frontend/templates/jsonld/product-offers.phtml
@@ -1,9 +1,43 @@
 <?php
-    $product = $block->getProduct();
-    if ($product && $product->getEntityId()):
-        $productSchema = $block->getSchemaJson();
-        $productData = json_decode((string) $productSchema, true);
-        $productId = is_array($productData) ? (string) ($productData['@id'] ?? '') : '';
+/**
+ * Async child-offers merger for configurable/bundle/grouped products.
+ *
+ * Layout uses Magento\Catalog\Block\Product\View (not OuterEdge Product),
+ * so this template must not call getSchemaJson(). Product @id matches
+ * Model\Type\Product: canonical product URL + "#Product".
+ *
+ * @var \Magento\Catalog\Block\Product\View $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+$product = $block->getProduct();
+if ($product && $product->getEntityId()):
+    $productId = '';
+    try {
+        $urlModel = $product->getUrlModel();
+        if ($urlModel && method_exists($urlModel, 'getUrl')) {
+            $url = (string) $urlModel->getUrl($product, [
+                '_ignore_category' => true,
+                '_scope_to_url' => true,
+            ]);
+            $url = preg_replace('/[?#].*$/', '', $url) ?: $url;
+            if ($url !== '') {
+                $productId = rtrim($url, '/') . '#Product';
+            }
+        }
+    } catch (\Throwable $e) {
+        $productId = '';
+    }
+    if ($productId === '') {
+        try {
+            $fallback = (string) $product->getProductUrl();
+            $fallback = preg_replace('/[?#].*$/', '', $fallback) ?: $fallback;
+            if ($fallback !== '') {
+                $productId = rtrim($fallback, '/') . '#Product';
+            }
+        } catch (\Throwable $e) {
+            $productId = '';
+        }
+    }
 ?>
 <script async>
     function fetchOffersSchema(ID) {
@@ -30,9 +64,13 @@
                 return true;
             }
 
-            // Only update the Product entity requested by this page. A type
-            // fallback can corrupt another extension's Product node.
-            if (targetId && Array.isArray(structuredDataJson['@graph'])) {
+            if (!Array.isArray(structuredDataJson['@graph'])) {
+                return;
+            }
+
+            // Prefer exact Product @id match so we never overwrite another
+            // extension's Product node.
+            if (targetId) {
                 const target = structuredDataJson['@graph'].find(
                     (n) => n && n['@id'] === targetId
                 );
@@ -40,6 +78,14 @@
                     structuredData.textContent = JSON.stringify(structuredDataJson);
                     return;
                 }
+            }
+
+            // Fallback: single Product entity in the graph.
+            const products = structuredDataJson['@graph'].filter(
+                (n) => n && n['@type'] === 'Product'
+            );
+            if (products.length === 1 && applyOffers(products[0])) {
+                structuredData.textContent = JSON.stringify(structuredDataJson);
             }
         }).catch(() => {
             // intentionally swallow - initial HTML must remain valid

--- a/view/frontend/templates/jsonld/product-reviewsio.phtml
+++ b/view/frontend/templates/jsonld/product-reviewsio.phtml
@@ -1,4 +1,11 @@
 <?php
+    // Guard: do not inject the reviews.io JSON-LD if the Magento
+    // @graph already contains a Product with reviews. Both sources
+    // would produce a duplicate Product entity for AI engines.
+    if ((int) $this->helper('OuterEdge\StructuredData\Helper\Config')->getConfig('structureddata/product/include_reviews') === 1) {
+        return;
+    }
+
     $product = $block->getProduct();
     if ($product->getTypeId() == 'configurable') {
         $associatedProducts = $product->getTypeInstance()->getUsedProducts($product);


### PR DESCRIPTION
## v6.0.0 — GEO / AEO structured data rewrite

Major release versus 5.2.x. JSON-LD is rebuilt as a single connected schema graph for stronger machine comprehension (generative search, answer engines, and traditional rich results), assuming configured data is accurate and output is validated on a real storefront.

### Why it matters
- **AEO** — clearer machine-readable answers about the business, products, categories, returns, and page purpose  
- **GEO** — stronger entity relationships and external grounding for generative search  
- **Traditional SEO** — cleaner Schema.org markup and better eligibility/interpretation for rich results  

Highest-confidence check: validate rendered homepage, category, product, CMS, and contact pages with the Schema.org Validator and Google Rich Results Test.

---

### Breaking changes
- **Single `@graph` document** — one `<script type="application/ld+json" id="structured-data">` with `@context` + `@graph` (Organization, WebSite, page, Product/ItemList, BreadcrumbList, etc.), not separate top-level JSON-LD blobs  
- **Placement** — main block moves from `head.additional` to `before.body.end`  
- **Breadcrumbs** — Hyvä / product breadcrumbs skip Magento’s built-in LD+JSON (`skip_ld_json_schema`); crumbs live only in the unified graph  
- **Templates rewritten** — `jsonld.phtml`, `cms.phtml`, `organization.phtml`, and `product-offers.phtml` use full JSON payloads / `@graph`-aware merging (no comma-fragment string splicing)  
- **Customer-specific integrations removed** from the generic module (site FAQ/CMS vendor hooks, hardcoded brand URLs, path-based special cases) — reimplement in a project module if needed  
- **Category `ItemList`** — uses the rendered `category.products.list` collection only (sort, layered nav, pagination); no independent fallback collection  
- **PHP 8.1+**; Jsonld DI surface expanded (Registry, Serializer, CategoryRepository, ImageHelper, PageConfig)

---

### Effective improvements
- **Connected `@graph`** linking Organization, WebSite, page, Product, ItemList, and BreadcrumbList  
- **Stable canonical `@id`s** (`/#org`, `/#website`, `…#webpage`, `…#breadcrumb`, `…#Product`) for entity reconciliation  
- **Richer page semantics** — `AboutPage`, `ContactPage`, `CollectionPage`, `ItemPage` (plus WebSite/WebPage/Search/Checkout), with description, `inLanguage`, `dateModified`, and `primaryImageOfPage` when available  
- **Organization `sameAs`** (one URL per line) for external entity grounding; legacy Related Pages still merged  
- **WebSite + SearchAction** sitelinks searchbox; `publisher` → Organization  
- **Products linked to categories**; **GTIN** as generic `gtin` plus length-specific `gtin8`/`gtin12`/`gtin13`/`gtin14` when valid  
- **Merchant return policy** on offers when return days are explicitly configured (optional return method)  
- **Visible category collection and breadcrumbs** so markup matches on-page content  
- **Consolidated fragments** and reliable Product ↔ Offer linking (including AJAX offers targeted by Product `@id` in `@graph`)  
- **Safer output** — canonical absolute URLs, placeholder image avoidance (gallery fallback), script-safe JSON encoding  

---

### Architecture
- Central `Block\Jsonld` + `jsonld.phtml` assemble the graph once per page  
- `BreadcrumbsPlugin` on `Magento\Theme\Block\Html\Breadcrumbs` so LD+JSON matches visible crumbs (Luma, Hyvä, custom themes)  
- **Extension hooks:** `getExtraGraphNodes()` and `extendPageEntity()` for site modules to add nodes / page links without HTML post-processing  
- Contact page `mainEntity` → Organization; homepage is WebSite only (no invalid CMS merge into WebSite)

---

### Product, category & CMS (detail)
- Product node restored in `@graph`; `ItemPage.mainEntity` links by `@id`  
- Category-independent canonical product URLs; absolute images; skip catalog placeholders  
- Top-level `color`, `size`, `material`, `keywords` where configured  
- Category text from deepest active assigned category (valid nav context preferred)  
- reviews.io guarded when core Magento reviews are also enabled  
- CMS AboutPage vs WebPage; homepage CMS child skipped so WebSite stays valid  

---

### Admin configuration
- **Organization (GEO):** social / external profile URLs (`sameAs`)  
- **Shipping & Returns (GEO):** default return window (days); optional return method (mail / in-store / kiosk)  

---

### Fixes & quality
- PHP 8.x `$pageConfig` typing fixed for `setup:di:compile`  
- Less ObjectManager/reflection; injected services where touched  
- Offers JS hardened against parse/empty responses  
- Graph consistency: one Organization, one WebSite; `@context` normalized to `https://schema.org/`  

---

### Upgrade notes
1. Diff theme overrides of JSON-LD templates, breadcrumbs, and default/product/category layout against 5.2.x  
2. Re-test homepage, category, product, CMS, and contact with Schema.org Validator and Google Rich Results Test  
3. Configure **sameAs** and **return policy** under Stores → Configuration → outer/edge → Structured Data if desired  
4. Move site-only schema (FAQs, brand URL rules, category filters) into a **project module** via the new hooks / product-type plugins  
5. Flush caches (including any structured-data cache type) after upgrade